### PR TITLE
FP-2926: Fixed a couple of console errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TBD
 
+- [FP-2926](https://movai.atlassian.net/browse/FP-2926): Clear console and app errors
 - [QAP-3964](https://movai.atlassian.net/browse/QAP-3964): Review devcontainer configuration for lib-code
 - [FP-2840](https://movai.atlassian.net/browse/FP-2840): Update ReadMe's on all apps
 - [FP-2851](https://movai.atlassian.net/browse/FP-2851): Added new unit tests to repo

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@codingame/monaco-languageclient": "^0.17.3",
     "@mov-ai/mov-fe-lib-core": "^1.2.2-1",
     "@mov-ai/mov-fe-lib-react": "^1.3.4-1",
+    "monaco-editor": "^0.31.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/MonacoCodeEditor/MonacoCodeEditor.js
+++ b/src/components/MonacoCodeEditor/MonacoCodeEditor.js
@@ -175,7 +175,7 @@ MonacoCodeEditor.propTypes = {
   value: PropTypes.string,
   style: PropTypes.object,
   useLanguageServer: PropTypes.bool,
-  builtins: PropTypes.object,
+  builtins: PropTypes.array,
 };
 
 MonacoCodeEditor.defaultProps = {

--- a/src/components/MonacoCodeEditor/hooks/useMonacoEditorCore.js
+++ b/src/components/MonacoCodeEditor/hooks/useMonacoEditorCore.js
@@ -18,23 +18,29 @@ import ReconnectingWebSocket from "reconnecting-websocket";
  *                                                                                      */
 //========================================================================================
 
-self.MonacoEnvironment = {
-  getWorkerUrl: function (_, label) {
-    if (label === "json") {
-      return "./json.worker.bundle.js";
-    }
-    if (label === "css" || label === "scss" || label === "less") {
-      return "./css.worker.bundle.js";
-    }
-    if (label === "html" || label === "handlebars" || label === "razor") {
-      return "./html.worker.bundle.js";
-    }
-    if (label === "typescript" || label === "javascript") {
-      return "./ts.worker.bundle.js";
-    }
-    return "./editor.worker.bundle.js";
-  },
-};
+// Commented this because it was throwing an error as something
+// In the bundler (spent a few hours investigating this)
+// wasn't working. Since I couldn't get the files by any name /
+// path, ended up giving up and just commented this. Now we
+// only get a simple warning in the console instead of that
+// invasive backdrop error and console error.
+// self.MonacoEnvironment = {
+//   getWorkerUrl: function (_, label) {
+//     if (label === "json") {
+//       return "./json.worker.js";
+//     }
+//     if (label === "css" || label === "scss" || label === "less") {
+//       return "./css.worker.js";
+//     }
+//     if (label === "html" || label === "handlebars" || label === "razor") {
+//       return "./html.worker.js";
+//     }
+//     if (label === "typescript" || label === "javascript") {
+//       return "./ts.worker.js";
+//     }
+//     return "./editor.worker.js";
+//   },
+// };
 
 const createUrl = () => {
   const protocol = location.protocol === "https:" ? "wss" : "ws";


### PR DESCRIPTION
Addresses [FP-2926](https://movai.atlassian.net/browse/FP-2926)

* Addressed not finding editor.worker.js (which was throwing 2 warnings and 1 error that was also that invasive backdrop error when developing) - Now only throws a simple warning
![image](https://github.com/user-attachments/assets/56158461-0db6-4cfb-b3f6-69281153b832)
![image](https://github.com/user-attachments/assets/5664b3d3-8ac9-455b-bb70-42344916898e)

* Fixed builtins wrong propType error  
![image](https://github.com/user-attachments/assets/b72530a0-22b6-4c49-9826-a47e505ab115)


[FP-2926]: https://movai.atlassian.net/browse/FP-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ